### PR TITLE
Add file header for ELPA compatibility

### DIFF
--- a/dokuwiki-mode.el
+++ b/dokuwiki-mode.el
@@ -1,3 +1,29 @@
+;;; dokuwiki-mode.el --- Major mode for DokuWiki document
+
+;; Copyright (C)  2013, 2014 Tsunenobu Kai
+
+;; Author: Tsunenobu Kai <kbkbkbkb1@gmail.com>
+;; URL: https://github.com/kbkbkbkb1/emacs-dokuwiki
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;; Code:
+
 (defgroup dokuwiki nil
   "Guide key bidings."
   :group 'text
@@ -132,3 +158,5 @@
   )
 
 (provide 'dokuwiki-mode)
+
+;;; dokuwiki-mode.el ends here


### PR DESCRIPTION
Hi, I plan to add this to [MELPA](http://melpa.milkbox.net/). This commit makes `dokuwiki-mode.el` installable with `package.el`. For information about this fix, See [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html).
