### PR TITLE
Correct URL referencing source

### DIFF
--- a/dokuwiki-mode.el
+++ b/dokuwiki-mode.el
@@ -3,7 +3,7 @@
 ;; Copyright (C)  2013, 2014 Tsunenobu Kai
 
 ;; Author: Tsunenobu Kai <kbkbkbkb1@gmail.com>
-;; URL: https://github.com/kbkbkbkb1/emacs-dokuwiki
+;; URL: https://github.com/kai2nenobu/emacs-dokuwiki-mode
 ;; Version: 0.1.0
 ;; Keywords: DokuWiki
 


### PR DESCRIPTION
The URL to the github repository containing the package source was incorrect and aimed at a nonexistent page.  Correct.