### PR TITLE
defadvice for symmetric headers

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,14 +1,38 @@
 * Overview
-Major mode for DokuWiki document
+Major mode for DokuWiki documents.
+
+Used by [[https://github.com/accidentalrebel/emacs-dokuwiki][dokuwiki]] (XMLRPC editing of live dokuwikis) and [[https://github.com/WillForan/zim-wiki-mode][zim-wiki-mode]] ([[https://zim-wiki.org][Zim Desktop Wiki]] uses dwiki format).
+
+* Install
+From melpa like ~M-x install-package dokuwiki-mode~ 
+
+Or buggy bleeding edge with [[https://github.com/quelpa/quelpa-use-package][quelpa-use-package]]
+#+begin_src emacs-lisp
+(use-package dokuwiki-mode
+  :quelpa ((dokuwiki-mode :fetcher github
+                     :repo "WillForan/dokuwiki-mode")
+           :upgrade t)
+  :ensure t
+  :config
+   (require 'outline-magic))
+
+#+end_src
+
+Either way, you'll likely want to make sure ~outline-magic~ is also loaded.
+
 * Features
 ** Highlight markup of DokuWiki
 ** Work with ~outline-magic~
 ~outline-magic~ enables to handle headings like ~org-mode~. If you load
-~outline-magic~, ~dokuwiki-mode~ use it.
+~outline-magic~, ~dokuwiki-mode~ will use it.
+
+The default key bindings for headers (a la org-mode) on ~meta-shift-arrow~ (outline-magic), ~C-c C-{n,p,f,b,u,@}~, and ~TAB/Shift-Tab~
+
 * TODOs
 - [ ] Highlight multiline block
-- [ ] Improve behavior of ~outline-promote~ and ~outline-demote~
 * ChangeLog
+- Version 0.1.2
+  - ~defadvice~ on outline-magic's promote, demote, and insert for symmetric ~===~ in headers.
 - Version 0.1.1
   - Change =defgroup= group name to avoid conflicting with [[https://github.com/accidentalrebel/emacs-dokuwiki][dokuwiki.el]] ([[https://github.com/kai2nenobu/emacs-dokuwiki-mode/pull/3][#3]] thanks [[https://github.com/zonuexe][@zonuexe]])
 - Version 0.1.0

--- a/dokuwiki-mode.el
+++ b/dokuwiki-mode.el
@@ -1,10 +1,12 @@
 ;;; dokuwiki-mode.el --- Major mode for DokuWiki document
 
 ;; Copyright (C)  2013-2017 Tsunenobu Kai
+;;
+;; 2023 - Contributions from Will Foran
 
 ;; Author: Tsunenobu Kai <kai2nenobu@gmail.com>
 ;; URL: https://github.com/kai2nenobu/emacs-dokuwiki-mode
-;; Version: 0.1.1
+;; Version: 0.1.2
 ;; Keywords: hypermedia text DokuWiki
 
 ;; This file is not part of GNU Emacs.
@@ -35,6 +37,7 @@
 
 (defvar dokuwiki-mode-map
   (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c RET") 'outline-insert-heading)
     (define-key map (kbd "C-c C-n") 'outline-next-visible-heading)
     (define-key map (kbd "C-c C-p") 'outline-previous-visible-heading)
     (define-key map (kbd "C-c C-f") 'outline-forward-same-level)
@@ -205,6 +208,9 @@ See also `outline-level'."
   "Advise promotion to update ending to symmetric '='."
   (when (derived-mode-p 'dokuwiki-mode) (dokuwiki-match-header)))
 (defadvice outline-demote (after dokuwiki-mode-demote activate)
+  "Advise demotion to update ending to symmetric '='."
+  (when (derived-mode-p 'dokuwiki-mode) (dokuwiki-match-header)))
+(defadvice outline-insert-heading (after dokuwiki-mode-insert-heading activate)
   "Advise demotion to update ending to symmetric '='."
   (when (derived-mode-p 'dokuwiki-mode) (dokuwiki-match-header)))
 

--- a/dokuwiki-mode.el
+++ b/dokuwiki-mode.el
@@ -170,15 +170,28 @@ See also `outline-level'."
       (- const (length headline)))))
 
 ;;;; Work with `outline-magic'
+(defun dokuwiki-outline-cycle-all ()
+  "Cycle all headings -- run as if point is at buffer top."
+  (interactive) (outline-cycle '(4)))
+
+(defun dokuwiki-outline-magic-set-bindings ()
+  "Bindings to demote/promote and cycle: functions provided by outline-magic."
+  (interactive)
+  (define-key dokuwiki-mode-map (kbd "TAB") 'outline-cycle)
+  (define-key dokuwiki-mode-map (kbd "<backtab>") #'outline-cycle)
+
+  (define-key dokuwiki-mode-map (kbd "<S-tab>") #'dokuwiki-outline-cycle-all)
+  (define-key dokuwiki-mode-map (kbd "M-<iso-lefttab>") #'dokuwiki-outline-cycle-all)
+
+  (define-key dokuwiki-mode-map (kbd "<M-S-right>") 'outline-demote)
+  (define-key dokuwiki-mode-map (kbd "<M-S-left>") 'outline-promote)
+  (define-key dokuwiki-mode-map (kbd "<M-up>") 'outline-move-subtree-up)
+  (define-key dokuwiki-mode-map (kbd "<M-down>") 'outline-move-subtree-down)
+  (define-key dokuwiki-mode-map (kbd "M-RET") #'dokuwiki-insert-next-header))
+
 (eval-after-load "outline-magic"
   '(progn
-     (define-key dokuwiki-mode-map (kbd "TAB") 'outline-cycle)
-     (define-key dokuwiki-mode-map (kbd "<S-tab>")
-       #'(lambda () (interactive) (outline-cycle '(4))))
-     (define-key dokuwiki-mode-map (kbd "<M-S-right>") 'outline-demote)
-     (define-key dokuwiki-mode-map (kbd "<M-S-left>") 'outline-promote)
-     (define-key dokuwiki-mode-map (kbd "<M-up>") 'outline-move-subtree-up)
-     (define-key dokuwiki-mode-map (kbd "<M-down>") 'outline-move-subtree-down)
+     ;; FIXME: need to do this buffer if all are done below?
      (add-hook 'dokuwiki-mode-hook 'dokuwiki-outline-magic-hook)
      ;; Enable outline-magic features in `dokuwiki-mode' buffers
      (dolist (buf (buffer-list))
@@ -187,6 +200,7 @@ See also `outline-level'."
 
 (defun dokuwiki-outline-magic-hook ()
   "Hook to configure `outline-magic'."
+  (dokuwiki-outline-magic-set-bindings)
   (set (make-local-variable 'outline-promotion-headings)
        '(("======" . 1) ("=====" . 2) ("====" . 3) ("===" . 4) ("==" . 5)))
   (set (make-local-variable 'outline-cycle-emulate-tab) t))

--- a/dokuwiki-mode.el
+++ b/dokuwiki-mode.el
@@ -203,6 +203,16 @@ See also `outline-level'."
       (kill-region b e)
       (insert rpl))))
 
+(defun dokuwiki-insert-next-header ()
+  "Insert next header level down from current.  Position cursor after markup."
+  (interactive)
+  (end-of-line)
+  (outline-insert-heading)
+  (delete-char 1)
+  (dokuwiki-match-header)
+  (skip-chars-forward "=")
+  (insert " "))
+
 
 (defadvice outline-promote (after dokuwiki-mode-promote activate)
   "Advise promotion to update ending to symmetric '='."


### PR DESCRIPTION
Thanks for providing this package! I use it every day to edit zim desktop wiki files. 

I added defadvice to promote, demote, and insert hoping to match the number `=` at the start and end. But the kludge requires `(outline-back-to-heading)` from outline-magic. 

I also added quelpa/use-package install instructions to the readme to highlight `outline-magic.` If it's something you'd think of incorporating,  you might want to change the `:repo` bit to match here.